### PR TITLE
Add optional Strum Machine link-out on tunes

### DIFF
--- a/app/controllers/tunes_controller.rb
+++ b/app/controllers/tunes_controller.rb
@@ -56,6 +56,6 @@ class TunesController < ApplicationController
   end
 
   def tune_params
-    params.require(:tune).permit(:name, :key, :time_signature, :strum_machine_url, genre_ids: [], user_ids: [], chart_ids: [])
+    params.require(:tune).permit(:name, :key, :time_signature, :strum_machine_url, :author, genre_ids: [], user_ids: [], chart_ids: [])
   end
 end

--- a/app/controllers/tunes_controller.rb
+++ b/app/controllers/tunes_controller.rb
@@ -56,6 +56,6 @@ class TunesController < ApplicationController
   end
 
   def tune_params
-    params.require(:tune).permit(:name, :key, :time_signature, genre_ids: [], user_ids: [], chart_ids: [])
+    params.require(:tune).permit(:name, :key, :time_signature, :strum_machine_url, genre_ids: [], user_ids: [], chart_ids: [])
   end
 end

--- a/app/models/tune.rb
+++ b/app/models/tune.rb
@@ -21,6 +21,7 @@ class Tune < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true, length: { minimum:3, maximum: 50 }
   validates :key, presence: true, length: { minimum:1, maximum: 5 }
+  validates :strum_machine_url, format: { with: /\Ahttps?:\/\//, message: "must be a valid URL" }, allow_blank: true
   
   scope :user_tunes, ->(user) { joins(:instruments).where(instruments: {id: user.instrument_ids}).distinct }
 

--- a/app/views/tunes/_form.html.erb
+++ b/app/views/tunes/_form.html.erb
@@ -15,6 +15,10 @@
       <%= f.text_field :time_signature, autofocus: true, class: "form-control" %>
     </div>
     <div class="form-group">
+      <%= f.label :strum_machine_url, "Strum Machine link (optional)", class: "control-label" %><br>
+      <%= f.text_field :strum_machine_url, placeholder: "https://strummachine.com/...", class: "form-control" %>
+    </div>
+    <div class="form-group">
       <%= f.label "Genres (check all that apply)" %><br>
       <%= f.collection_check_boxes :genre_ids, Genre.all, :id, :name do |cb| %>
         <% cb.label(class: "checkbox-inline input_checkbox") {cb.check_box(class: "checkbox") + cb.text} %>

--- a/app/views/tunes/_form.html.erb
+++ b/app/views/tunes/_form.html.erb
@@ -15,6 +15,10 @@
       <%= f.text_field :time_signature, autofocus: true, class: "form-control" %>
     </div>
     <div class="form-group">
+      <%= f.label :author, "Author (optional)" %><br>
+      <%= f.text_field :author, class: "form-control" %>
+    </div>
+    <div class="form-group">
       <%= f.label :strum_machine_url, "Strum Machine link (optional)", class: "control-label" %><br>
       <%= f.text_field :strum_machine_url, placeholder: "https://strummachine.com/...", class: "form-control" %>
     </div>

--- a/app/views/tunes/show.html.erb
+++ b/app/views/tunes/show.html.erb
@@ -26,6 +26,11 @@
       <%= link_to "Add Lyrics", new_tune_lyric_path(@tune), class: 'btn btn-md btn-primary edit-tune' %>
     <% end %>
     <%= link_to "Add Chord Chart", new_tune_chart_path(@tune), class: 'btn btn-md btn-primary edit-tune' %>
+    <% if @tune.strum_machine_url.present? %>
+      <%= link_to @tune.strum_machine_url, target: "_blank", rel: "noopener", class: 'btn btn-md btn-info edit-tune' do %>
+        Practice on Strum Machine <i class="fa fa-external-link" aria-hidden="true"></i>
+      <% end %>
+    <% end %>
     <% if @tune.tunings.any? %>
       <%= link_to "Edit tunings", edit_multiple_tune_tune_tunings_path(@tune), 
           class: 'btn btn-md btn-warning' %>

--- a/app/views/tunes/show.html.erb
+++ b/app/views/tunes/show.html.erb
@@ -4,6 +4,9 @@
   <div>
     <h3>Key: <%= @tune.key %></h3>
     <h3>Time Signature: <%= @tune.time_signature %></h3>
+    <% if @tune.author.present? %>
+      <h3>Author: <%= @tune.author %></h3>
+    <% end %>
     <h3>Genre(s): 
       <% if @tune.genres.any? %>
         <% @tune.genres.each do |genre| %>

--- a/db/migrate/20260717203507_add_strum_machine_url_to_tunes.rb
+++ b/db/migrate/20260717203507_add_strum_machine_url_to_tunes.rb
@@ -1,0 +1,5 @@
+class AddStrumMachineUrlToTunes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tunes, :strum_machine_url, :string
+  end
+end

--- a/db/migrate/20260718003250_add_author_to_tunes.rb
+++ b/db/migrate/20260718003250_add_author_to_tunes.rb
@@ -1,0 +1,5 @@
+class AddAuthorToTunes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tunes, :author, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_01_181042) do
+ActiveRecord::Schema.define(version: 2026_07_17_203507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 2021_11_01_181042) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "time_signature"
+    t.string "strum_machine_url"
   end
 
   create_table "tunings", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_17_203507) do
+ActiveRecord::Schema.define(version: 2026_07_18_003250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -200,6 +200,7 @@ ActiveRecord::Schema.define(version: 2026_07_17_203507) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "time_signature"
     t.string "strum_machine_url"
+    t.string "author"
   end
 
   create_table "tunings", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Adds an optional `strum_machine_url` field to `Tune` so a tune can link out to its corresponding individual song on [strummachine.com](https://strummachine.com/) for practice.
- Adds an optional `author` field to `Tune` to record the fiddler/source a particular arrangement comes from.
- No deeper API integration exists with Strum Machine yet — this is a link-out convenience only.
- Both fields are optional; `strum_machine_url` is validated as an `http(s)://` URL when present.

## Test plan
- [x] Migrated dev DB and confirmed both schema changes apply cleanly
- [x] Logged in and edited a tune, setting `strum_machine_url` and `author` — confirmed both save and render on the show page ("Practice on Strum Machine" button links out correctly; "Author: ..." displays when present)
- [x] Submitted an invalid (non-URL) `strum_machine_url` — confirmed validation error re-renders the edit form
- [x] Cleared `strum_machine_url` (blank) — confirmed it saves and the button disappears with no errors
- [x] Verified individual per-song Strum Machine links (not just list-level links) resolve correctly for a bulk-seeded set of tunes